### PR TITLE
Add external API functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,11 +8,18 @@ We used Lab 5 from the QMUL cloud computing module [1] as the basis for our appl
 
 - Clone this repo onto GCP VM instance (see lab notes for creating VM instance)
 - Open terminal on your instance (see lab notes for how)
-- From terminal go to the app folder `cd cloud_computing_coursework_g44/app`
-- Build: `sudo docker build . -t my_first_app_image:v1`
-- Run: `sudo docker run -p 80:80 my_first_app_image:v1`
-- Test it works by going to the IP address of your VM instance, you should see a page saying 'Hello World'
+- Use the following commands to install docker:
+  - `sudo apt update`
+  - `sudo apt install docker.io`
+- From terminal go to the app folder:
+  - `cd cloud_computing_coursework_g44/app`
+- Build:
+  - `sudo docker build . -t music_app`
+- Run:
+  - `sudo docker run -p 80:80 music_app`
+- Test it works by going to the IP address of your VM instance, you should see a page saying 'Welcome to music finder!'
 - If you now add `/records/all_bands/` to the URL you should see '["Radiohead","Portishead"]'
+- Try `<ext_ip>/records/video/Radiohead` and you should get a link to an itunes video by radiohead
 
 # References
 

--- a/README.md
+++ b/README.md
@@ -17,9 +17,13 @@ We used Lab 5 from the QMUL cloud computing module [1] as the basis for our appl
   - `sudo docker build . -t music_app`
 - Run:
   - `sudo docker run -p 80:80 music_app`
-- Test it works by going to the IP address of your VM instance, you should see a page saying 'Welcome to music finder!'
+- Test it works by going to the IP address of your VM instance, add :80 (for the port), you should see a page saying 'Welcome to music finder!'
 - If you now add `/records/all_bands/` to the URL you should see '["Radiohead","Portishead"]'
-- Try `<ext_ip>/records/video/Radiohead` and you should get a link to an itunes video by radiohead
+
+# External API
+- We've implemented a call to the iTunes API which will return a URL to a video by the users chosen band. The way to make the call is as follows
+  - `<GCLOUD_EXT_IP>:80/records/video/<BAND_NAME>`
+  - e.g. http://35.234.153.246:80/records/video/portishead would get a link to an iTunes video by Portishead if your GCloud external ip were 35.234.153.246
 
 # References
 

--- a/app/myapp.py
+++ b/app/myapp.py
@@ -1,4 +1,5 @@
 from flask import Flask, jsonify
+import requests
 
 all_records = [
     {
@@ -39,40 +40,55 @@ app = Flask(__name__)
 
 @app.route('/')
 def hello():
-    return('<h1>Hello World!</h1>')
+    return('<h1>Welcome to music finder!</h1>')
 
 
 @app.route('/records/', methods=['GET'])
 def get_records():
     return jsonify(all_records)
 
+
 @app.route('/records/all_bands/', methods=['GET'])
 def get_bands():
     response = [item['name'] for item in all_records]
     return jsonify(response)
 
+
 @app.route('/records/albums_by_band/<bandname>/', methods=['GET'])
 def get_album_by_band(bandname):
-    response={bandname:'Not Found!'}
+    response = {bandname: 'Not Found!'}
     for item in all_records:
 
-        if item["name"]==bandname:
+        if item["name"] == bandname:
             response = [x["title"] for x in item["albums"]]
             break
     return jsonify(response)
 
+
 @app.route('/records/<bandname>/<album>/', methods=['GET'])
 def get_description_of_album(bandname, album):
-    response={album:'Not Found!'}
+    response = {album: 'Not Found!'}
     for item in all_records:
-        if item["name"]==bandname:
+        if item["name"] == bandname:
             for album_title in item['albums']:
                 if album_title['title'] == album:
                     response = album_title['description']
                     break
     return jsonify(response)
 
+
+@app.route('/records/<bandname>/video', methods=['GET'])
+def get_video(bandname):
+    # takes a band name, returns URL to iTunes video if it exists
+    try:
+        formatted_bandname = "+".join(bandname.split())
+        itunes_request = f"https://itunes.apple.com/search?term={formatted_bandname}&entity=musicVideo&limit=1"
+        itunes_response_json = requests.get(itunes_request).json()
+        itunes_url = itunes_response_json['results'][0]["previewUrl"]
+        return(f"<h1>Here's a great video by {bandname}! {itunes_url}</h1>")
+
+    except:
+        return(f"<h1>Sorry, we couldn't find a video by {bandname} for you :(</h1>")
+
 if __name__ == '__main__':
     app.run(host='0.0.0.0', port=80)
-
-

--- a/app/myapp.py
+++ b/app/myapp.py
@@ -86,7 +86,7 @@ def get_video(bandname):
         itunes_response_json = requests.get(itunes_request).json()
         itunes_url = itunes_response_json['results'][0]["previewUrl"]
         itunes_url_with_quotes = f'"{itunes_url}"'
-        return(f"<h1>Here's a great video by {bandname}! <a href={itunes_url_with_quotes}>{itunes_url}</a></h1>")
+        return(f"<h1>Here's a great video by {bandname}!\n<a href={itunes_url_with_quotes}>{itunes_url}</a></h1>")
 
     except:
         return(f"<h1>Sorry, we couldn't find a video by {bandname} for you :(</h1>")

--- a/app/myapp.py
+++ b/app/myapp.py
@@ -85,7 +85,8 @@ def get_video(bandname):
         itunes_request = f"https://itunes.apple.com/search?term={formatted_bandname}&entity=musicVideo&limit=1"
         itunes_response_json = requests.get(itunes_request).json()
         itunes_url = itunes_response_json['results'][0]["previewUrl"]
-        return(f"<h1>Here's a great video by {bandname}! {itunes_url}</h1>")
+        itunes_url_with_quotes = f'"{itunes_url}"'
+        return(f"<h1>Here's a great video by {bandname}! <a href={itunes_url_with_quotes}>{itunes_url}</a></h1>")
 
     except:
         return(f"<h1>Sorry, we couldn't find a video by {bandname} for you :(</h1>")

--- a/app/myapp.py
+++ b/app/myapp.py
@@ -86,7 +86,7 @@ def get_video(bandname):
         itunes_response_json = requests.get(itunes_request).json()
         itunes_url = itunes_response_json['results'][0]["previewUrl"]
         itunes_url_with_quotes = f'"{itunes_url}"'
-        return(f"<h1>Here's a great video by {bandname}!\n<a href={itunes_url_with_quotes}>{itunes_url}</a></h1>")
+        return(f"<h1>Here's a great video by {bandname}!</h1><h2><a href={itunes_url_with_quotes}>{itunes_url}</a></h2>")
 
     except:
         return(f"<h1>Sorry, we couldn't find a video by {bandname} for you :(</h1>")

--- a/app/myapp.py
+++ b/app/myapp.py
@@ -77,7 +77,7 @@ def get_description_of_album(bandname, album):
     return jsonify(response)
 
 
-@app.route('/records/<bandname>/video', methods=['GET'])
+@app.route('/records/video/<bandname>', methods=['GET'])
 def get_video(bandname):
     # takes a band name, returns URL to iTunes video if it exists
     try:

--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -1,1 +1,2 @@
 Flask
+requests


### PR DESCRIPTION
User can now get a link to a video by their chosen band from the iTunes API by constructing a URL in following format:

<GCLOUD_EXT_IP>:80/records/video/<BAND_NAME>

e.g: http://35.234.153.246:80/records/video/portishead